### PR TITLE
Update to Crystal 0.31.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,13 +10,13 @@ license: MIT
 
 dependencies:
   lucky:
-    github: luckyframework/lucky
-    version: ~> 0.17.0
+    github: bcardiff/lucky
+    branch: crystal/0.31.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4
 
 development_dependencies:
   avram:
-    github: luckyframework/avram
-    version: ~> 0.11.0
+    github: bcardiff/avram
+    branch: crystal/0.31.0

--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -35,5 +35,5 @@ module Authentic::ActionHelpers(T)
     end
   end
 
-  abstract def find_current_user(id) : T
+  abstract def find_current_user(id) : T?
 end


### PR DESCRIPTION
While upgrading to Crystal 0.31.0 without warnings I noticed an inconsistency with respect: 

https://github.com/luckyframework/lucky_cli/blob/0857059def5ae08f31da947bca7d140d7e15a23b/src/browser_app_skeleton/src/actions/browser_action.cr.ecr#L28-L30

The `Temp` commit is a placeholder to remember to bump dependencies:
* https://github.com/luckyframework/lucky/pull/918
* https://github.com/luckyframework/avram/pull/243