### PR TITLE
Fix outdated inline docs

### DIFF
--- a/src/authentic.cr
+++ b/src/authentic.cr
@@ -81,10 +81,12 @@ module Authentic
   # Encrypts a form password
   #
   # ```crystal
-  # class SignUpForm < User::FormHelpers
+  # class SignUpUser < User::SaveOperation
   #   attribute password : String
   #
-  #   def prepare
+  #   before_save encrypt_password
+  #
+  #   def encrypt_password
   #     # Encrypt the `password` and copy the value to the `encrypted_password` field
   #     Authentic.copy_and_encrypt password, to: encrypted_password
   #   end


### PR DESCRIPTION
`FormHelpers` were removed in #26

I also wonder if this example should be closer to full source here or maybe with some parts removed https://github.com/luckyframework/lucky_cli/blob/master/src/base_authentication_app_skeleton/src/operations/sign_up_user.cr