### PR TITLE
Allow encrypted_password to be nil

### DIFF
--- a/spec/action_helpers_spec.cr
+++ b/spec/action_helpers_spec.cr
@@ -5,7 +5,7 @@ class Authentication::TestAction < Lucky::Action
 
   get "/test-auth" { text "Doesn't matter" }
 
-  private def find_current_user(id)
+  private def find_current_user(id) : FakeAuthenticatable
     FakeAuthenticatable.new(id: id.to_i)
   end
 end

--- a/spec/authentic_spec.cr
+++ b/spec/authentic_spec.cr
@@ -82,9 +82,11 @@ describe Authentic do
   it "can check whether the given password is correct or not" do
     encrypted_password = Authentic.generate_encrypted_password("password")
     authenticatable = FakeAuthenticatable.new(encrypted_password: encrypted_password)
+    authenticatable_without_password = FakeAuthenticatable.new(encrypted_password: nil)
 
     Authentic.correct_password?(authenticatable, "password").should be_true
     Authentic.correct_password?(authenticatable, "incorrect password").should be_false
+    Authentic.correct_password?(authenticatable_without_password, "anything").should be_false
   end
 
   it "can save an encrypted password to a Avram::Attribute" do

--- a/spec/support/fake_authenticatable.cr
+++ b/spec/support/fake_authenticatable.cr
@@ -1,8 +1,9 @@
 class FakeAuthenticatable
   include Authentic::PasswordAuthenticatable
 
-  getter id, encrypted_password
+  getter id : Int32
+  getter encrypted_password : String?
 
-  def initialize(@id : Int32 = 1, @encrypted_password : String = "abc123")
+  def initialize(@id = 1, @encrypted_password = "abc123")
   end
 end

--- a/src/authentic/password_authenticatable.cr
+++ b/src/authentic/password_authenticatable.cr
@@ -1,4 +1,4 @@
 module Authentic::PasswordAuthenticatable
   abstract def id
-  abstract def encrypted_password : String
+  abstract def encrypted_password : String?
 end


### PR DESCRIPTION
Related to #27

The problem with enforcing encrypted_password was that if you wanted to
have email/password sign in *and/or* some other social sign in then
it would not work. You'd have to set "encrypted_password" to "fake" or
some other hack.

This update makes it so you can make encrypted_password nil if you want.