### PR TITLE
Alters email column to citext type

### DIFF
--- a/db/migrations/20180416193329_create_users.cr
+++ b/db/migrations/20180416193329_create_users.cr
@@ -1,15 +1,10 @@
 class CreateUsers::V20180416193329 < Avram::Migrator::Migration::V1
   def migrate
+    enable_extension "citext"
     create :users do
-      add email : String, unique: true
+      add email : String, unique: true, case_sensitive: false
       add encrypted_password : String
     end
-    execute <<-SQL
-    CREATE EXTENSION IF NOT EXISTS citext;
-SQL
-    execute <<-SQL
-    ALTER TABLE users ALTER COLUMN email TYPE citext;
-SQL
   end
 
   def rollback

--- a/db/migrations/20180416193329_create_users.cr
+++ b/db/migrations/20180416193329_create_users.cr
@@ -4,6 +4,12 @@ class CreateUsers::V20180416193329 < Avram::Migrator::Migration::V1
       add email : String, unique: true
       add encrypted_password : String
     end
+    execute <<-SQL
+    CREATE EXTENSION IF NOT EXISTS citext;
+SQL
+    execute <<-SQL
+    ALTER TABLE users ALTER COLUMN email TYPE citext;
+SQL
   end
 
   def rollback


### PR DESCRIPTION
Fixes #9 

Inspired by : http://shuber.io/case-insensitive-unique-constraints-in-postgres/

**Do not merge this as it is** : 
- I believe there must be a more elegant solution (Create a `CIString` type in Avram to automatically create a citext column type and use it in Authentic ?)
- There is no spec written to test this
- There is no error handling 

Edit : https://www.postgresql.org/docs/current/citext.html