### PR TITLE
Replaced Void with Nil

### DIFF
--- a/src/authentic.cr
+++ b/src/authentic.cr
@@ -44,7 +44,7 @@ module Authentic
   #
   # Once the user signs in call `Authentic.redirect_to_originally_requested_path`
   # to redirect them back.
-  def self.remember_requested_path(action : Lucky::Action) : Void
+  def self.remember_requested_path(action : Lucky::Action) : Nil
     if action.request.method.upcase == "GET"
       action.session.set(:return_to, action.request.resource)
     end
@@ -101,7 +101,7 @@ module Authentic
   def self.copy_and_encrypt(
     from password_field : Avram::Attribute | Avram::PermittedAttribute,
     to encrypted_password_field : Avram::Attribute | Avram::PermittedAttribute
-  ) : Void
+  ) : Nil
     password_field.value.try do |value|
       encrypted_password_field.value = generate_encrypted_password(value)
     end

--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -3,12 +3,12 @@ module Authentic::ActionHelpers(T)
   SIGN_IN_KEY = "user_id"
 
   # Signs a user in using the browser session.
-  def sign_in(authenticatable : T) : Void
+  def sign_in(authenticatable : T) : Nil
     session.set(SIGN_IN_KEY, authenticatable.id.to_s)
   end
 
   # Sign the user out by clearing the session.
-  def sign_out : Void
+  def sign_out : Nil
     session.clear
   end
 


### PR DESCRIPTION
Fixes #60 
Void should only be used in C lib extensions.