### PR TITLE
memoize the current_user? method.

### DIFF
--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -28,7 +28,7 @@ module Authentic::ActionHelpers(T)
   #
   # This method should *not* be overridden. If you want to require a current user,
   # override the `current_user` method (note no `?`).
-  def current_user? : T?
+  memoize def current_user? : T?
     id = session.get?(SIGN_IN_KEY)
     if id
       find_current_user(id)

--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -24,15 +24,20 @@ module Authentic::ActionHelpers(T)
     current_user?
   end
 
+  # TODO: https://github.com/luckyframework/lucky/issues/1396
+  @__current_user : T? = nil
+
   # Return the signed in user if signed in, otherwise returns `nil`
   #
   # This method should *not* be overridden. If you want to require a current user,
   # override the `current_user` method (note no `?`).
-  memoize def current_user? : T?
-    id = session.get?(SIGN_IN_KEY)
-    if id
-      find_current_user(id)
-    end
+  def current_user? : T?
+    @__current_user ||= ->{
+      id = session.get?(SIGN_IN_KEY)
+      if id
+        find_current_user(id)
+      end
+    }.call
   end
 
   abstract def find_current_user(id) : T?

--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -32,12 +32,12 @@ module Authentic::ActionHelpers(T)
   # This method should *not* be overridden. If you want to require a current user,
   # override the `current_user` method (note no `?`).
   def current_user? : T?
-    @__current_user ||= ->{
+    @__current_user ||= begin
       id = session.get?(SIGN_IN_KEY)
       if id
         find_current_user(id)
       end
-    }.call
+    end
   end
 
   abstract def find_current_user(id) : T?


### PR DESCRIPTION
Fixes #32

Since we include Lucky as a dependency of this library, we know that `memoize` exists at the `Object` level

https://github.com/luckyframework/lucky/blob/0fcd828851266b9bb5d2ca4695d0ebdca352a675/src/charms/object.cr#L3