### PR TITLE
Move the secret_key validation to Habitat. 

### DIFF
--- a/src/authentic.cr
+++ b/src/authentic.cr
@@ -158,8 +158,4 @@ module Authentic
     user_id, expiration_in_ms = String.new(encryptor.verify_and_decrypt(token)).split(":")
     Time.utc.to_unix_ms <= expiration_in_ms.to_i64 && user_id.to_s == authenticatable.id.to_s
   end
-
-  private def self.secret_key
-    {% raise "Authentic.secret_key has been removed. Use Authentic.settings.secret_key instead." %}
-  end
 end

--- a/src/authentic.cr
+++ b/src/authentic.cr
@@ -34,7 +34,22 @@ module Authentic
   Habitat.create do
     setting encryption_cost : Int32 = Crypto::Bcrypt::DEFAULT_COST
     setting default_password_reset_time_limit : Time::Span = 15.minutes
-    setting secret_key : String
+    setting secret_key : String, validation: :validate_length
+  end
+
+  def self.validate_length(value : String)
+    if value.bytesize != 32
+      Habitat.raise_validation_error <<-ERROR
+
+      Authentic secret_key setting must be 32 bytes long.
+
+      Try this...
+
+        ▸ Generate a new key with `lucky gen.secret_key`
+        ▸ Set the secret_key value in your Authentic.configure block
+
+      ERROR
+    end
   end
 
   # Remember the originally requested path if it is a GET
@@ -145,9 +160,6 @@ module Authentic
   end
 
   private def self.secret_key
-    if settings.secret_key.length != 32
-      raise "Authentic secret_key must be 32 characters long"
-    end
-    settings.secret_key
+    {% raise "Authentic.secret_key has been removed. Use Authentic.settings.secret_key instead." %}
   end
 end


### PR DESCRIPTION
Fixes #61

The error message before indicated that it had to be 32 characters, but that wasn't necessarily correct. You can use emoji as valid cypher keys, and 1 emoji could contain 6 bytes making it less than 32 characters. 

Here's what the new error would look like.

<img width="806" alt="Screen Shot 2021-07-21 at 9 45 59 AM" src="https://user-images.githubusercontent.com/2391/126527259-f514c2d1-0cd3-4e03-a937-c285dce06d51.png">
