### PR TITLE
Fix the secret_key validation to allow any string >= 32 bytes

### DIFF
--- a/src/authentic.cr
+++ b/src/authentic.cr
@@ -38,10 +38,11 @@ module Authentic
   end
 
   def self.validate_length(value : String)
-    if value.bytesize != 32
+    if value.bytesize < 32
       Habitat.raise_validation_error <<-ERROR
 
-      Authentic secret_key setting must be 32 bytes long.
+      Authentic secret_key setting must be at least 32 bytes long,
+      but got #{value.bytesize} bytes '#{value}'.
 
       Try this...
 


### PR DESCRIPTION
This gets pushed down to `OpenSSL::Cipher` which requires at least 32 bytes. The error you get from Crystal is a little misleading which made me think it had to be exactly 32.

> Unhandled exception: Key length too short: wanted 32, got 28 (ArgumentError)

```crystal
require "openssl/cipher"
require "random/secure"
 
str = Random::Secure.base64(32)
 
cipher = OpenSSL::Cipher.new("aes-256-cbc")
cipher.encrypt
cipher.key = str
iv = cipher.random_iv
encrypted_data = IO::Memory.new
encrypted_data.write(cipher.update("super secret"))
encrypted_data.write(cipher.final)
encrypted_data.write(iv)
 
encrypted_data.to_slice
```