### PR TITLE
Adding a type restriction to find_current_user

### DIFF
--- a/spec/action_helpers_spec.cr
+++ b/spec/action_helpers_spec.cr
@@ -5,7 +5,7 @@ class Authentication::TestAction < Lucky::Action
 
   get "/test-auth" { text "Doesn't matter" }
 
-  private def find_current_user(id) : FakeAuthenticatable
+  private def find_current_user(id : String | FakeAuthenticatable::PrimaryKeyType) : FakeAuthenticatable
     FakeAuthenticatable.new(id: id.to_i)
   end
 end

--- a/spec/support/fake_authenticatable.cr
+++ b/spec/support/fake_authenticatable.cr
@@ -1,5 +1,6 @@
 class FakeAuthenticatable
   include Authentic::PasswordAuthenticatable
+  alias PrimaryKeyType = Int32
 
   getter id : Int32
   getter encrypted_password : String?

--- a/src/authentic/action_helpers.cr
+++ b/src/authentic/action_helpers.cr
@@ -31,12 +31,11 @@ module Authentic::ActionHelpers(T)
   # override the `current_user` method (note no `?`).
   def current_user? : T?
     @__current_user ||= begin
-      id = session.get?(Authentic.settings.sign_in_key)
-      if id
+      if id = session.get?(Authentic.settings.sign_in_key)
         find_current_user(id)
       end
     end
   end
 
-  abstract def find_current_user(id) : T?
+  abstract def find_current_user(id : String | T::PrimaryKeyType) : T?
 end


### PR DESCRIPTION
Adding the type restriction to this method allows it to be memoized. This also fixes a compilation issue in lucky_cli